### PR TITLE
QA

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :development do
 end
 
 group :test do
-  gem 'refinerycms-testing'
+  gem 'refinerycms-testing', path: './testing'
   gem 'generator_spec', '~> 0.9.3'
   gem 'launchy'
   gem 'coveralls', require: false

--- a/core/lib/refinery/core/configuration.rb
+++ b/core/lib/refinery/core/configuration.rb
@@ -59,7 +59,7 @@ module Refinery
       end
 
       def dragonfly_custom_backend_class
-        Refinery.deprecate("Refinery::Dragonfly now handles all dragonfly configuration. Consult 'config/initializers/refinery/dragonfly.rb'.")
+        raise "Refinery::Dragonfly now handles all dragonfly configuration. Consult 'config/initializers/refinery/dragonfly.rb'."
       end
 
       def site_name

--- a/images/refinerycms-images.gemspec
+++ b/images/refinerycms-images.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files             = `git ls-files`.split("\n")
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
-  s.add_dependency 'dragonfly',               '~> 1.1'
+  s.add_dependency 'refinerycms-dragonfly',   '~> 1.0'
   s.add_dependency 'globalize',               ['>= 5.1.0.beta1', '< 5.2']
   s.add_dependency 'activemodel-serializers-xml', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'refinerycms-core',        version

--- a/resources/refinerycms-resources.gemspec
+++ b/resources/refinerycms-resources.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'globalize',               ['>= 5.1.0.beta1', '< 5.2']
   s.add_dependency 'activemodel-serializers-xml', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'refinerycms-core',        version
-  s.add_dependency 'refinerycms-dragonfly',   '~>1.0'
+  s.add_dependency 'refinerycms-dragonfly',   '~> 1.0'
 
   s.required_ruby_version = Refinery::Version.required_ruby_version
 


### PR DESCRIPTION
I've made a little QA on your dragonfly PR. 

I have rollbacked the change for the `dragonfly_custom_backend_class ` method, i didn't see we do the same thing on the next setter `wymeditor_whitelist_tags=`

It's important to use the local `refinerycms-testing` engine instead of the rubygems source. For example, without this change, i could not manage to update the Rails version from 4.2 to 5.1.